### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 HTGradientEasing
 ================
 
-##Overview
+## Overview
 
 Easily add smooth easing to CAGradientLayers.  A combination of the exhaustive collection of easing functions provided by the AHEasing project and a color mixer, UIColor+CrossFade. 
 
@@ -14,7 +14,7 @@ The Mach Bands effect exaggerates our perception of the hard lines at the ends o
 * https://github.com/warrenm/AHEasing
 * https://github.com/cbpowell/UIColor-CrossFade
 
-##Installation
+## Installation
 
 Include the following line in your podfile:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
